### PR TITLE
Update kube command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,14 @@ To access your application, you want to create an ingress to connect all the mic
 kubectl create -f manifests/ingress.yaml
 ```
 
-You can check the public IP address of your cluster through `kubectl get nodes` and get the NodePort of the istio-ingress service for port 80 through `kubectl get svc | grep istio-ingress`. Or you can also run the following command to output the IP address and NodePort:
+You can check the public IP address of your cluster through `bx cs workers <your_cluster_name>` and get the NodePort of the istio-ingress service for port 80 through `kubectl get svc | grep istio-ingress`. Or you can also run the following command to output the IP address and NodePort:
 ```bash
-echo $(kubectl get pod -l istio=ingress -o jsonpath={.items[0].status.hostIP}):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
-#This should output your IP:NodePort e.g. 184.172.247.2:30344
+echo $(bx cs workers <your_cluster_name> | grep normal | awk '{ print $2;exit }'):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
+# Replace <your_cluster_name> with your cluster name. This should output your IP:NodePort e.g. 184.172.247.2:30344
 ```
 
 Point your browser to:  
-`http://<IP:NodePort>` Replace with your own IP and NodePort.
+`http://<IP:NodePort>` Replace `<IP:NodePort>` with your own IP and NodePort.
 
 Congratulations, you MicroProfile application is running and it should look like [this](microprofile_ui.md).
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ kubectl create -f manifests/ingress.yaml
 
 You can check the public IP address of your cluster through `bx cs workers <your_cluster_name>` and get the NodePort of the istio-ingress service for port 80 through `kubectl get svc | grep istio-ingress`. Or you can also run the following command to output the IP address and NodePort:
 ```bash
-echo $(bx cs workers <your_cluster_name> | grep normal | awk '{ print $2;exit }'):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
+echo $(bx cs workers <your_cluster_name> | grep normal | awk '{ print $2 }' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
 # Replace <your_cluster_name> with your cluster name. This should output your IP:NodePort e.g. 184.172.247.2:30344
 ```
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 echo "Creating Java MicroProfile App"
 
-IP_ADDR=$(bx cs workers $CLUSTER_NAME | grep normal | awk '{ print $2 }')
+IP_ADDR=$(bx cs workers $CLUSTER_NAME | grep normal | awk '{ print $2;exit }')
 if [ -z $IP_ADDR ]; then
   echo "$CLUSTER_NAME not created or workers not ready"
   exit 1
@@ -71,7 +71,7 @@ echo "Java MicroProfile done."
 echo "Getting IP and Port"
 kubectl get nodes
 kubectl get svc | grep ingress
-export GATEWAY_URL=$(kubectl get po -l istio=ingress -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -o 'jsonpath={.spec.ports[0].nodePort}')
+export GATEWAY_URL=$IP_ADDR:$(kubectl get svc istio-ingress -o 'jsonpath={.spec.ports[0].nodePort}')
 echo $GATEWAY_URL
 if [ -z "$GATEWAY_URL" ]
 then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 echo "Creating Java MicroProfile App"
 
-IP_ADDR=$(bx cs workers $CLUSTER_NAME | grep normal | awk '{ print $2;exit }')
+IP_ADDR=$(bx cs workers $CLUSTER_NAME | grep normal | awk '{ print $2 }' | head -1)
 if [ -z $IP_ADDR ]; then
   echo "$CLUSTER_NAME not created or workers not ready"
   exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,7 +86,7 @@ echo "MicroProfile done."
 
 function health_check() {
 
-export GATEWAY_URL=$(kubectl get po -l istio=ingress -o jsonpath={.items[0].status.hostIP}):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
+export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2;exit }'):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
 sleep 60s #wait for Websphere Liberty to be up
 HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
 if [ $HEALTH -eq 200 ]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,7 +88,8 @@ function health_check() {
 
 export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2}' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
 sleep 60s #wait for Websphere Liberty to be up
-HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
+export HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
+echo $HEALTH
 if [ $HEALTH -eq 200 ]
 then
   echo "Everything looks good."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,7 +87,7 @@ echo "MicroProfile done."
 function health_check() {
 
 export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2 }' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
-sleep 60s #wait for Websphere Liberty to be up
+sleep 150s #wait for Websphere Liberty to be up
 export HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
 if [ $HEALTH -eq 200 ]
 then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,6 +91,9 @@ sleep 60s #wait for Websphere Liberty to be up
 echo $GATEWAY_URL
 export HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
 echo $HEALTH
+sleep 5s
+export HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
+echo $HEALTH
 if [ $HEALTH -eq 200 ]
 then
   echo "Everything looks good."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,12 +88,7 @@ function health_check() {
 
 export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2 }' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
 sleep 60s #wait for Websphere Liberty to be up
-echo $GATEWAY_URL
 export HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
-echo $HEALTH
-sleep 5s
-export HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
-echo $HEALTH
 if [ $HEALTH -eq 200 ]
 then
   echo "Everything looks good."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,8 +86,9 @@ echo "MicroProfile done."
 
 function health_check() {
 
-export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2}' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
+export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2 }' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
 sleep 60s #wait for Websphere Liberty to be up
+echo $GATEWAY_URL
 export HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
 echo $HEALTH
 if [ $HEALTH -eq 200 ]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,7 +86,7 @@ echo "MicroProfile done."
 
 function health_check() {
 
-export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2;exit }'):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
+export GATEWAY_URL=$(bx cs workers $CLUSTER | grep normal | awk '{ print $2}' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
 sleep 60s #wait for Websphere Liberty to be up
 HEALTH=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL)
 if [ $HEALTH -eq 200 ]


### PR DESCRIPTION
Due to the changes on the new Bluemix Cluster, `kubectl get nodes` only can obtain the private IP. Thus, we need to use `bx cs workers` command to get the public IP.