### PR TITLE
Fix Travis CI and add new badges/notices for the pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ MicroProfile Fault Tolerance, adding application-specific capabilities such as f
 
 ## Included Components
 - [MicroProfile](https://microprofile.io)
-- [Istio (1.6)](https://istio.io/)
+- [Istio (1.6)](https://istio.io/v-0.1/docs/)
 - [Kubernetes Clusters](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov)
 - [Cloudant](https://www.ibm.com/analytics/us/en/technology/cloud-data-services/cloudant/)
 - [Bluemix DevOps Toolchain Service](https://console.ng.bluemix.net/catalog/services/continuous-delivery)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/IBM/resilient-java-microservices-with-istio.svg?branch=master)](https://travis-ci.org/IBM/resilient-java-microservices-with-istio)
+![Bluemix Deployments](https://metrics-tracker.mybluemix.net/stats/d72bb55cd318bc218ace273bf0789833/badge.svg)
 
 # Enable your Java microservices with advanced resiliency features leveraging Istio 
 
@@ -26,7 +27,7 @@ MicroProfile Fault Tolerance, adding application-specific capabilities such as f
 
 ## Included Components
 - [MicroProfile](https://microprofile.io)
-- [Istio](https://istio.io/)
+- [Istio (1.6)](https://istio.io/)
 - [Kubernetes Clusters](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov)
 - [Cloudant](https://www.ibm.com/analytics/us/en/technology/cloud-data-services/cloudant/)
 - [Bluemix DevOps Toolchain Service](https://console.ng.bluemix.net/catalog/services/continuous-delivery)
@@ -41,7 +42,7 @@ If you want to deploy the Java MicroProfile app directly to Bluemix, click on 'D
 
 > You will need to create your Kubernetes cluster first and make sure it is fully deployed in your Bluemix account.
 
-[![Create Toolchain](https://github.com/IBM/container-journey-template/blob/master/images/button.png)](https://console.ng.bluemix.net/devops/setup/deploy/)
+[![Create Toolchain](https://metrics-tracker.mybluemix.net/stats/d72bb55cd318bc218ace273bf0789833/button.svg)](https://console.ng.bluemix.net/devops/setup/deploy/)
 
 Please follow the [Toolchain instructions](https://github.com/IBM/container-journey-template/blob/master/Toolchain_Instructions_new.md) to complete your toolchain and pipeline.
 
@@ -350,6 +351,8 @@ mvn clean package
 ```
 
 * Your microservice vote will use cloudantDB as the database, and it will initialize the database on your first POST request on the application. Therefore, when you vote on the speaker/session for your first time, please only vote once within the first 10 seconds to avoid causing a race condition on creating the new database.
+
+* Please avoid using Kubernetes 1.7.x on this example since version 1.7.x has a bug that will corrupt the cloudant database pods.
 
 # References
 [Istio.io](https://istio.io/docs/tasks/index.html)

--- a/manifests/deploy-broken-cloudant.yaml
+++ b/manifests/deploy-broken-cloudant.yaml
@@ -17,6 +17,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: cloudant-pv-claim2
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
   labels:
     app: microprofile-app
 spec:

--- a/manifests/deploy-cloudant.yaml
+++ b/manifests/deploy-cloudant.yaml
@@ -17,6 +17,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: cloudant-pv-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
   labels:
     app: microprofile-app
 spec:

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -8,4 +8,4 @@ kubectl apply -f <(istioctl kube-inject -f manifests/deploy-cloudant.yaml --incl
 kubectl apply -f <(istioctl kube-inject -f manifests/deploy-vote.yaml)
 kubectl apply -f <(istioctl kube-inject -f manifests/deploy-webapp.yaml)
 kubectl get nodes
-kubectl get svc istio-ingress
+kubectl get svc -n istio-system istio-ingress

--- a/tests/test-kubeadm-dind-cluster.sh
+++ b/tests/test-kubeadm-dind-cluster.sh
@@ -15,7 +15,6 @@ kubectl_deploy() {
     curl -L https://git.io/getIstio | sh -
     cd $(ls | grep istio)
     export PATH="$PATH:$(pwd)/bin"
-    kubectl apply -f install/kubernetes/istio-rbac-alpha.yaml
     kubectl apply -f install/kubernetes/istio.yaml
 
     echo "Running scripts/quickstart.sh"
@@ -38,7 +37,7 @@ kubectl_deploy() {
 
 verify_deploy(){
     echo "Verifying deployment was successful"
-    if ! curl -sS http://$(bx cs workers [docker username] | grep normal | awk '{ print $2 }' | head -1):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort}); then
+    if ! sleep 1 && curl -sS "$(kubectl get svc -n istio-system istio-ingress | grep istio-ingress | awk '{ print $2 }')":$(kubectl get svc -n istio-system istio-ingress -o jsonpath={.spec.ports[0].nodePort}); then
         test_failed "$0"
     fi
 }

--- a/tests/test-kubernetes.sh
+++ b/tests/test-kubernetes.sh
@@ -32,10 +32,10 @@ kubectl_deploy() {
 
     echo "install Istio"
     curl -L https://git.io/getIstio | sh -
-    cd $(ls | grep istio)
+    pushd $(ls | grep istio)
     export PATH="$PATH:$(pwd)/bin"
     kubectl apply -f install/kubernetes/istio.yaml
-    cd ..
+    popd
 
     echo "Running scripts/quickstart.sh"
     "$(dirname "$0")"/../scripts/quickstart.sh


### PR DESCRIPTION
- Use local storage instead of file storage to speed up Travis CI build time.
- Fix Travis CI to install Istio add-on and check the correct IP and Port
- Add badges for the metrics tracker
- Add notice for Kubernetes 1.7.x since it will corrupt our Cloudant image.
- Add notice to indicate this Pattern is using Istio 1.6 (since Istio 2.x uses different format to create pilot policy)