### PR TITLE
Migrate this Code Pattern to use Istio 2.12 or above.

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -49,7 +49,7 @@ stages:
       application: Pipeline
     script: |
       #!/bin/bash
-      . ./scripts/install_bx.sh
+      . ./scripts/install.sh
       ./scripts/bx_login.sh
       ./scripts/deploy.sh
 hooks:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ MicroProfile Fault Tolerance, adding application-specific capabilities such as f
 - [WebSphere](https://developer.ibm.com/wasdev/websphere-liberty)
 
 # Prerequisite
-- Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, with [IBM Cloud Private](https://github.com/IBM/deploy-ibm-cloud-private/blob/master/README.md), or with [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template/blob/master/README.md) to deploy in cloud. The code here is regularly tested against [Kubernetes Cluster from Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov) using Travis.
-- You will also need Istio service mesh installed on top of your Kubernetes cluster. Please follow the instructions, [Istio getting started](https://github.com/IBM/Istio-getting-started), to get Istio mesh installed on Kubernetes.
+- Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, with [IBM Cloud Private](https://github.com/IBM/deploy-ibm-cloud-private/blob/master/README.md), or with [IBM Bluemix Container Service](https://console.bluemix.net/docs/containers/container_index.html#clusters) to deploy in cloud. The code here is regularly tested against [Kubernetes Cluster from Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov) using Travis.
+- You will also need Istio service mesh installed on top of your Kubernetes cluster. Please follow the instructions, [Istio Quick Start](https://istio.io/docs/setup/kubernetes/quick-start.html), to get Istio mesh installed on Kubernetes.
 
 # Steps
 

--- a/manifests/circuit-breaker-db.yaml
+++ b/manifests/circuit-breaker-db.yaml
@@ -1,15 +1,16 @@
-type: destination-policy
-name: db-circuit
+apiVersion: config.istio.io/v1alpha2
+kind: DestinationPolicy
+metadata:
+  name: db-circuit
+  namespace: default
 spec:
-  destination: cloudant-service.default.svc.cluster.local
-  policy:
-    - circuitBreaker:
-        simpleCb:
-          maxConnections: 1
-          httpMaxPendingRequests: 1
-          httpConsecutiveErrors: 1
-          sleepWindow: 15m
-          httpDetectionInterval: 1s
-          httpMaxEjectionPercent: 100
-          
-        
+  destination: 
+    name: cloudant-service
+  circuitBreaker:
+    simpleCb:
+      maxConnections: 1
+      httpMaxPendingRequests: 1
+      httpConsecutiveErrors: 1
+      sleepWindow: 15m
+      httpDetectionInterval: 1s
+      httpMaxEjectionPercent: 100

--- a/manifests/fault-injection.yaml
+++ b/manifests/fault-injection.yaml
@@ -1,13 +1,12 @@
-type: route-rule
-name: cloudant-delay
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: cloudant-delay
+  namespace: default
 spec:
-  destination: cloudant-service.default.svc.cluster.local
-  precedence: 2
+  destination: 
+    name: cloudant-service
   httpFault:
     delay:
       percent: 100
       fixedDelay: 1.1s
-    # abort:
-    #   percent: 10
-    #   httpStatus: 503
-      

--- a/manifests/timeout-vote.yaml
+++ b/manifests/timeout-vote.yaml
@@ -1,12 +1,12 @@
-type: route-rule
-name: timeout
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: timeout
+  namespace: default
 spec:
-  destination: vote-service.default.svc.cluster.local
+  destination: 
+    name: vote-service
   httpReqTimeout:
     simpleTimeout:
       timeout: 1s
-  # httpReqRetries:
-  #   simpleRetry:
-  #     attempts: 3
-  #     perTryTimeout: 1s
       

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,7 +28,6 @@ echo "install Istio"
 curl -L https://git.io/getIstio | sh -
 cd $(ls | grep istio)
 export PATH="$PATH:$(pwd)/bin"
-kubectl apply -f install/kubernetes/istio-rbac-alpha.yaml
 kubectl apply -f install/kubernetes/istio.yaml
 
 #Make sure all the pods are running before proceeding to the next step.
@@ -71,7 +70,7 @@ echo "Java MicroProfile done."
 echo "Getting IP and Port"
 kubectl get nodes
 kubectl get svc | grep ingress
-export GATEWAY_URL=$IP_ADDR:$(kubectl get svc istio-ingress -o 'jsonpath={.spec.ports[0].nodePort}')
+export GATEWAY_URL=$IP_ADDR:$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
 echo $GATEWAY_URL
 if [ -z "$GATEWAY_URL" ]
 then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,13 +18,6 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s ht
 chmod 0755 kubectl
 sudo mv kubectl /usr/local/bin
 
-echo "install Istio"
-curl -L https://git.io/getIstio | sh -
-cd $(ls | grep istio)
-export PATH="$PATH:$(pwd)/bin"
-kubectl apply -f install/kubernetes/istio-rbac-alpha.yaml
-kubectl apply -f install/kubernetes/istio.yaml
-
 echo "Install the Bluemix container-service plugin"
 bx plugin install container-service -r Bluemix
 

--- a/tests/test-kubeadm-dind-cluster.sh
+++ b/tests/test-kubeadm-dind-cluster.sh
@@ -4,9 +4,9 @@
 source "$(dirname "$0")"/../scripts/resources.sh
 
 setup_dind-cluster() {
-    wget https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.7.sh
-    chmod 0755 dind-cluster-v1.7.sh
-    ./dind-cluster-v1.7.sh up
+    wget https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.8.sh
+    chmod 0755 dind-cluster-v1.8.sh
+    ./dind-cluster-v1.8.sh up
     export PATH="$HOME/.kubeadm-dind-cluster:$PATH"
 }
 


### PR DESCRIPTION
* Update all RouteRules and DestinationPolicies from Istio 1.6 to 2.12
* Update any command that needs to match with the new Istio 2.12 version
* Update Istio Quick Start instruction link to the newest version
* This Pattern now only works on Kubernetes 1.8 and above (Istio requires K8s 1.7+ and Cloudant image has problem with K8s 1.7.x)
* Update Travis to use Kubernetes 1.8 and Istio 2.12
* Fix Deploy to IBM Cloud button to work with Istio 2.12