### PR TITLE
Configure bx cli to disable version check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,10 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s ht
 chmod 0755 kubectl
 sudo mv kubectl /usr/local/bin
 
+echo "Configuring bx to disable version check"
+bx config --check-version=false
+echo "Checking bx version"
+bx --version
 echo "Install the Bluemix container-service plugin"
 bx plugin install container-service -r Bluemix
 


### PR DESCRIPTION
As @AnthonyAmanse points out at https://github.com/IBM/Scalable-WordPress-deployment-on-Kubernetes/pull/41, the current travis build fails because it's waiting for an input. This PR will disable the update option for bx cli.

Signed-off-by: Tomcli Tommy.chaoping.li@ibm.com